### PR TITLE
デプロイをあきらめ

### DIFF
--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -8,8 +8,7 @@ const options = {
 
 const client = applyCaseMiddleware(
   axios.create({
-    baseURL: 'https://e-code-backend.herokuapp.com/api/v1'
-    // baseURL: 'http://localhost:8080/api/v1'
+    baseURL: 'http://localhost:8080/api/v1'
   }),
   options
 )


### PR DESCRIPTION
# 概要
* ViteのRollUpがpackage[aws-sdk]と相性が悪く、デプロイできてもエラーになってしまう。